### PR TITLE
Potential fix for code scanning alert no. 4: CSRF protection weakened or disabled

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  protect_from_forgery
+  protect_from_forgery with: :exception
 end


### PR DESCRIPTION
Potential fix for [https://github.com/arisal2/Dashboard-for-Covid-and-Medical-Diagnosis/security/code-scanning/4](https://github.com/arisal2/Dashboard-for-Covid-and-Medical-Diagnosis/security/code-scanning/4)

The best fix is to make CSRF behavior explicit and strict by configuring forgery protection to raise on invalid/missing tokens.

In `app/controllers/application_controller.rb`, replace the current bare `protect_from_forgery` call with `protect_from_forgery with: :exception`. This preserves normal application functionality for valid requests while ensuring suspicious requests fail immediately rather than continuing with a nulled/altered session state. No additional methods, helpers, or imports are required; this is a one-line configuration hardening in the existing controller base class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
