### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fluffy_octo_system.yml
+++ b/.github/workflows/fluffy_octo_system.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+
 env:
   RUBY_VERSION: '3.2.6'
   NODE_VERSION: '20'


### PR DESCRIPTION
Potential fix for [https://github.com/arisal2/Dashboard-for-Covid-and-Medical-Diagnosis/security/code-scanning/3](https://github.com/arisal2/Dashboard-for-Covid-and-Medical-Diagnosis/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (`linters`, `test`, `build`) unless overridden.  
For this workflow, the minimal least-privilege setting is:

- `contents: read`

This supports `actions/checkout` and keeps token scope constrained. No functionality changes are introduced.

**File to edit:** `.github/workflows/fluffy_octo_system.yml`  
**Change location:** near the top-level keys, right after `on:` block (before `env:` is a clean placement).  
No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
