### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fluffy_octo_system.yml
+++ b/.github/workflows/fluffy_octo_system.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+
 env:
   RUBY_VERSION: '3.2.6'
   NODE_VERSION: '20'


### PR DESCRIPTION
Potential fix for [https://github.com/arisal2/Dashboard-for-Covid-and-Medical-Diagnosis/security/code-scanning/2](https://github.com/arisal2/Dashboard-for-Covid-and-Medical-Diagnosis/security/code-scanning/2)

Add an explicit top-level `permissions` block in `.github/workflows/fluffy_octo_system.yml` so all jobs default to least privilege.

Best fix here (without changing functionality):  
- Insert at workflow root (after `on:` block, before `env:`):  
  - `permissions:`  
  - `contents: read`  

Why this is best:  
- It addresses all jobs (`linters`, `test`, `build`) in one place.  
- Current jobs only need read access to repository contents and artifact upload does not require elevating repo write scopes.  
- It matches CodeQL guidance and preserves behavior.

No imports/methods/dependencies are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
