### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fluffy_octo_system.yml
+++ b/.github/workflows/fluffy_octo_system.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+
 env:
   RUBY_VERSION: '3.2.6'
   NODE_VERSION: '20'


### PR DESCRIPTION
Potential fix for [https://github.com/arisal2/Dashboard-for-Covid-and-Medical-Diagnosis/security/code-scanning/1](https://github.com/arisal2/Dashboard-for-Covid-and-Medical-Diagnosis/security/code-scanning/1)

Add an explicit workflow-level `permissions` block near the top of `.github/workflows/fluffy_octo_system.yml` so all jobs inherit least-privilege defaults.

Best single fix (without changing functionality): add:

- `permissions:`
  - `contents: read`

Place it after the `on:` block (or before `jobs:`). This satisfies CodeQL and documents intended token scope. None of the shown jobs require repository write permissions, so `contents: read` is the appropriate minimal baseline.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
